### PR TITLE
Adding missing PHP 7.3 entry

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -53,7 +53,7 @@ $releases = @{
     "7.0" = "7.0.33"
     "7.1" = "7.1.33"
     "7.2" = "7.2.34"
-    "7.3" = "7.3.32"
+    "7.3" = "7.3.33"
 }
 $phpversion = $releases.$version
 if (-not $phpversion) {

--- a/run.ps1
+++ b/run.ps1
@@ -53,6 +53,7 @@ $releases = @{
     "7.0" = "7.0.33"
     "7.1" = "7.1.33"
     "7.2" = "7.2.34"
+    "7.3" = "7.3.32"
 }
 $phpversion = $releases.$version
 if (-not $phpversion) {


### PR DESCRIPTION
Add this as it's no longer part of `https://windows.php.net/downloads/releases/releases.json`.