### PR TITLE
Output Visual Studio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ change in future releases.
   needs to be passed to the ilammy/msvc-dev-cmd action
 - `prefix`: the prefix of the PHP installation;
   needs to be passed to configure
+- `vs`: the Visual Studio version

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,11 @@ outputs:
     description: "The required toolset version"
     value: ${{steps.setup.outputs.toolset}}
   prefix:
-    description: The prefix of the PHP installation
+    description: "The prefix of the PHP installation"
     value: ${{steps.setup.outputs.prefix}}
+  vs:
+    description: "The Visual Studio version"
+    value: ${{steps.setup.outputs.vs}}
 runs:
   using: "composite"
   steps:

--- a/run.ps1
+++ b/run.ps1
@@ -129,3 +129,4 @@ Add-Content $Env:GITHUB_PATH "$pwd\php-dev"
 
 Write-Output "::set-output name=toolset::$toolset"
 Write-Output "::set-output name=prefix::$pwd\php-bin"
+Write-Output "::set-output name=vs::$vs"


### PR DESCRIPTION
Hi! This commit allows to output the selected VS version (`crt`).

[Example](https://github.com/codemasher/php-ext-xz/blob/6257c238cd8cd9ba48095255fefafebfcd1c37ff/.github/workflows/ci.yml#L117):

```
php_xz-${{ env.file_tag }}-${{ matrix.php }}-${{ matrix.ts }}-${{ steps.sdk.outputs.vs }}-${{ matrix.arch }}.dll
```

outputs: `php_xz-f668a23-8.0-ts-vs16-x64.dll`