### PR TITLE
Migrate deprecated set-output commands to use $GITHUB_OUTPUT

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -127,6 +127,6 @@ Add-Content $Env:GITHUB_PATH "$pwd\php-sdk\msys2\usr\bin"
 Add-Content $Env:GITHUB_PATH "$pwd\php-bin"
 Add-Content $Env:GITHUB_PATH "$pwd\php-dev"
 
-Write-Output "::set-output name=toolset::$toolset"
-Write-Output "::set-output name=prefix::$pwd\php-bin"
-Write-Output "::set-output name=vs::$vs"
+Write-Output "toolset=$toolset" >> $GITHUB_OUTPUT
+Write-Output "prefix=$pwd\php-bin" >> $GITHUB_OUTPUT
+Write-Output "vs=$vs" >> $GITHUB_OUTPUT

--- a/run.ps1
+++ b/run.ps1
@@ -127,6 +127,6 @@ Add-Content $Env:GITHUB_PATH "$pwd\php-sdk\msys2\usr\bin"
 Add-Content $Env:GITHUB_PATH "$pwd\php-bin"
 Add-Content $Env:GITHUB_PATH "$pwd\php-dev"
 
-Write-Output "toolset=$toolset" >> $GITHUB_OUTPUT
-Write-Output "prefix=$pwd\php-bin" >> $GITHUB_OUTPUT
-Write-Output "vs=$vs" >> $GITHUB_OUTPUT
+Write-Output "toolset=$toolset" >> $Env:GITHUB_OUTPUT
+Write-Output "prefix=$pwd\php-bin" >> $Env:GITHUB_OUTPUT
+Write-Output "vs=$vs" >> $Env:GITHUB_OUTPUT


### PR DESCRIPTION
This should resolve deprecation notices when using this action:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I also referenced https://github.com/oliverjfletcher/actions-testing/blob/main/.github/workflows/set-ouput-test.yml for Powershell-specific syntax.