### PR TITLE
Use vs16 for php 8.3 in run.ps1

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -16,6 +16,7 @@ $versions = @{
     "8.0" = "vs16"
     "8.1" = "vs16"
     "8.2" = "vs16"
+    "8.3" = "vs16"
 }
 $vs = $versions.$version
 if (-not $vs) {


### PR DESCRIPTION
PHP 8.3.0 stable was released, so support building DLLs for it (https://windows.php.net/download/)

vs16 is used by https://github.com/php/php-src/blob/PHP-8.3.0/.github/workflows/push.yml#L180